### PR TITLE
added simple length check for the length of the line split

### DIFF
--- a/quote.go
+++ b/quote.go
@@ -229,6 +229,9 @@ func NewQuoteFromCSV(symbol, csv string) (Quote, error) {
 
 	for row, bar := 1, 0; row < numrows; row, bar = row+1, bar+1 {
 		line := strings.Split(tmp[row], ",")
+		if len(line) != 6 {
+			break
+		}
 		q.Date[bar], _ = time.Parse("2006-01-02 15:04", line[0])
 		q.Open[bar], _ = strconv.ParseFloat(line[1], 64)
 		q.High[bar], _ = strconv.ParseFloat(line[2], 64)


### PR DESCRIPTION
Add a length check before reading the line variable.

```
// NewQuoteFromCSV - parse csv quote string into Quote structure
func NewQuoteFromCSV(symbol, csv string) (Quote, error) {

	tmp := strings.Split(csv, "\n")
	numrows := len(tmp)
	q := NewQuote(symbol, numrows-1)

	for row, bar := 1, 0; row < numrows; row, bar = row+1, bar+1 {
		line := strings.Split(tmp[row], ",")
		if len(line) != 6 {
			break
		}
```
This helps to stop any out of bounds errors, which I was running into