### PR TITLE
Use http status code to confirm the ticker existed for using Tiingo as the source

### DIFF
--- a/quote.go
+++ b/quote.go
@@ -839,16 +839,21 @@ func tiingoDaily(symbol string, from, to time.Time, token string) (Quote, error)
 	resp, err := client.Do(req)
 
 	if err != nil {
-		Log.Printf("symbol '%s' not found\n", symbol)
+		Log.Printf("tiingo error: %v\n", err)
 		return NewQuote("", 0), err
 	}
 	defer resp.Body.Close()
 
-	contents, _ := ioutil.ReadAll(resp.Body)
-
-	err = json.Unmarshal(contents, &tiingo)
-	if err != nil {
-		Log.Printf("tiingo error: %v\n", err)
+	if resp.StatusCode == http.StatusOK {
+		contents, _ := ioutil.ReadAll(resp.Body)
+		err = json.Unmarshal(contents, &tiingo)
+		if err != nil {
+			Log.Printf("tiingo error: %v\n", err)
+			return NewQuote("", 0), err
+		}
+	} else if resp.StatusCode == http.StatusNotFound {
+		Log.Printf("symbol '%s' not found\n", symbol)
+		return NewQuote("", 0), err
 	}
 
 	numrows := len(tiingo)


### PR DESCRIPTION
### What is the issue
When using `Tiingo` as source to search a ticker, it will return `tiingo error: json: cannot unmarshal object into Go value of type []quote.tquote` if the ticker not existed. We would like to have more informative message instead of the unmarshal error. 

### What's in the PR
With some investigations, the `tiingo` will return a json message with 404 status code if the ticker not existed. For example:
```json
{
    "detail": "Error: Ticker 'SEB-A.ST' not found"
}
```
To solve the issue, we would like to check status code in `resp` before `json.Unmarshal` to return the correct message. 
