### PR TITLE
Set User-Agent, Accept, Content-Type on NewMarketList requests

### DIFF
--- a/quote.go
+++ b/quote.go
@@ -1665,7 +1665,12 @@ func NewMarketList(market string) ([]string, error) {
 		url = "https://api.pro.coinbase.com/products"
 	}
 
-	resp, err := http.Get(url)
+	req, err := http.NewRequest("GET", url, nil)
+	req.Header.Add("User-Agent", "markcheno/go-quote")
+	req.Header.Add("Accept", "application/xml")
+	req.Header.Add("Content-Type", "application/xml; charset=utf-8")
+	client := &http.Client{}
+	resp, err := client.Do(req)
 	if err != nil {
 		return symbols, err
 	}


### PR DESCRIPTION
Omitting these headers was resulting in a timeout for the basic download command:

```
quote nyse
```