### PR TITLE
Fix allmarkets command

### DIFF
--- a/quote.go
+++ b/quote.go
@@ -1750,10 +1750,6 @@ func getCoinbaseMarket(market, rawdata string) ([]string, error) {
 
 // NewMarketFile - download a list of market symbols to a file
 func NewMarketFile(market, filename string) error {
-
-	if !ValidMarket(market) {
-		return fmt.Errorf("invalid market")
-	}
 	if market == "allmarkets" {
 		for _, m := range ValidMarkets {
 			filename = m + ".txt"
@@ -1765,6 +1761,9 @@ func NewMarketFile(market, filename string) error {
 			ioutil.WriteFile(filename, ba, 0644)
 		}
 		return nil
+	}
+	if !ValidMarket(market) {
+		return fmt.Errorf("invalid market")
 	}
 
 	// default filename

--- a/quote/main.go
+++ b/quote/main.go
@@ -339,15 +339,19 @@ func outputIndividual(symbols []string, flags quoteflags) error {
 }
 
 func handleCommand(cmd string, flags quoteflags) bool {
+	var err error
+
 	// handle market special commands
-	if !quote.ValidMarket(cmd) {
-		return false
-	}
 	switch cmd {
 	case "etf":
-		quote.NewEtfFile(flags.outfile)
+		err = quote.NewEtfFile(flags.outfile)
 	default:
-		quote.NewMarketFile(cmd, flags.outfile)
+		err = quote.NewMarketFile(cmd, flags.outfile)
+	}
+
+	if err != nil {
+		quote.Log.Println(err)
+		return false
 	}
 	return true
 }


### PR DESCRIPTION
I tried to run `allmarkets` command but it was not working.

Problem was with `ValidMarket` function which was executed before `allmarkets` command handler in `quote.go`.

Additionally:
- Removed (seemingly) redundant `ValidMarket` call in `quote/main.go`
- Added error logging in command handler function